### PR TITLE
Fix GET /journals endpoint - invalid orderBy parameter causing faults

### DIFF
--- a/journaly-backend/src/journals/journals.service.ts
+++ b/journaly-backend/src/journals/journals.service.ts
@@ -15,7 +15,7 @@ export class JournalsService {
   async findAll(userId: string) {
     return await this.prisma.journal.findMany({
       where: { userId },
-      orderBy: { createdAt: 'invalid' as any }
+      orderBy: { createdAt: 'desc' }
     });
   }
 


### PR DESCRIPTION
## Issue Description
CloudWatch alarm "GET /journal alarm" was triggered, indicating faults in the `journaly-backend` service for the `GET /journals` endpoint operation.

**Incident ID:** cw-GET /journal alarm-1771222759992

**Alarm Details:**
- **Service:** journaly-backend
- **Environment:** dev
- **Operation:** GET /journals?userId={userId}
- **Metric:** ApplicationSignals Fault metric
- **State:** ALARM (triggered at 2026-02-16 06:19:19 UTC)

## Root Cause
The `findAll` method in `journaly-backend/src/journals/journals.service.ts` contained an invalid `orderBy` parameter that was causing database queries to fail.

**Problematic Code (Line 16):**
```typescript
orderBy: { createdAt: 'invalid' as any }
```

The code was explicitly setting the sort order to `'invalid'`, which is not a valid Prisma sort order value. Prisma only accepts `'asc'` (ascending) or `'desc'` (descending) as valid sort order values. This invalid parameter caused all GET /journals requests to fail, resulting in the faults reported by ApplicationSignals.

## Solution
Changed the `orderBy` parameter from `'invalid'` to `'desc'` to sort journals by creation date in descending order (newest first).

**Fixed Code:**
```typescript
orderBy: { createdAt: 'desc' }
```

This ensures that:
1. The database query executes successfully
2. Journals are returned in a logical order (newest first)
3. The GET /journals endpoint returns 200 OK instead of failing

## Testing
After deploying this fix:
- Verify that GET /journals?userId={userId} requests succeed
- Confirm that journals are returned in descending order by createdAt
- Monitor the ApplicationSignals Fault metric to ensure it returns to OK state

## Files Changed
- `journaly-backend/src/journals/journals.service.ts` - Fixed invalid orderBy parameter in findAll method